### PR TITLE
SCALRCORE-9068 (libcloud) OpenStack driver's get_service_catalog() doesn't follow proxy_url

### DIFF
--- a/libcloud/common/openstack_identity.py
+++ b/libcloud/common/openstack_identity.py
@@ -590,6 +590,9 @@ class OpenStackIdentityConnection(ConnectionUserAndKey):
         # enable tests to use the same mock connection classes.
         if parent_conn:
             self.conn_class = parent_conn.conn_class
+            self.retry_delay = parent_conn.retry_delay
+            self.backoff = parent_conn.backoff
+            self.proxy_url = parent_conn.proxy_url
             self.driver = parent_conn.driver
         else:
             self.driver = None


### PR DESCRIPTION
… 

## Changes Title (replace this with a logical title for your changes)

### Description

Replace this with the PR description (mention the changes you have made, why
you have made them, provide some background and any references to the provider
documentation if needed, etc.).

For more information on contributing, please see [Contributing](http://libcloud.readthedocs.org/en/latest/development.html#contributing)
section of our documentation.

### Status

Replace this: describe the PR status. Examples:

- work in progress
- done, ready for review

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
